### PR TITLE
patch to correct link to contributing guidlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ following values are just examples):
 
 ## Contributing
 
-Please read through our <a href="https://github.com/artefactual/binder/blob/master/CONTRIBUTING.md">contributing guidelines</a>.
+Please read through our <a href="https://github.com/artefactual/binder/blob/master/CONTRIBUTING">contributing guidelines</a>.
 Included are directions for opening issues, coding standards, and notes on
 development.
 


### PR DESCRIPTION
Link to CONTRIBUTING produces 404 error because it assumes a .md extension when there is not one.
